### PR TITLE
Update version of httpntlm dependency to fix arbitrary code execution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodemailer-ntlm-auth",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "NTLM authentication module for Nodemailer",
     "main": "index.js",
     "scripts": {
@@ -10,7 +10,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "httpntlm": "1.7.6"
+        "httpntlm": "1.7.7"
     },
     "devDependencies": {
         "eslint": "5.12.0",


### PR DESCRIPTION
Vulnerability details:
```
underscore  1.3.2 - 1.12.0
Severity: high
Arbitrary Code Execution in underscore - https://github.com/advisories/GHSA-cf4h-3jhx-xvhq
No fix available
```

PR in `httpntlm` repo, detailing the fix: [https://github.com/SamDecrock/node-http-ntlm/pull/93](https://github.com/SamDecrock/node-http-ntlm/pull/93)