### PR TITLE
Update version of httpntlm dependency to support nodejs v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "httpntlm": "1.7.7"
+        "httpntlm": "1.8.12"
     },
     "devDependencies": {
         "eslint": "5.12.0",


### PR DESCRIPTION
Original issue: https://github.com/SamDecrock/node-http-ntlm/issues/103